### PR TITLE
fix(release): feat bumps minor not patch

### DIFF
--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -30,7 +30,7 @@ Version bumps are determined automatically from commit message prefixes:
 | `docs:` | `docs: improve setup guide` | No bump (shown in changelog) |
 | `perf:` | `perf: optimise bundle size` | Patch |
 
-> **Note:** While the repo is pre-1.0 (`0.x.y`), `feat:` bumps the minor version and `fix:` bumps the patch, as configured by `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` in `release-please-config.json`. A `BREAKING CHANGE` still bumps major.
+> **Note:** While the repo is pre-1.0 (`0.x.y`), `feat:` bumps the minor version and `fix:` bumps the patch, as configured by `bump-minor-pre-major` in `release-please-config.json`. A `BREAKING CHANGE` still bumps major.
 
 ---
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
       "include-v-in-tag": true,


### PR DESCRIPTION
## Problem

`bump-patch-for-minor-pre-major: true` was overriding `bump-minor-pre-major: true`, causing `feat:` commits to produce a **patch** bump (`0.2.0 → 0.2.1`) instead of the intended **minor** bump (`0.2.0 → 0.3.0`). This is what caused the first release-please Release PR to show `0.2.1` for a new feature.

## Fix

Remove `bump-patch-for-minor-pre-major` from `release-please-config.json`. With only `bump-minor-pre-major: true` set, the behaviour is:

| Commit type | Version bump |
|---|---|
| `feat:` | Minor (`0.2.0 → 0.3.0`) |
| `fix:` | Patch (`0.2.0 → 0.2.1`) |
| `BREAKING CHANGE` | Major (`0.2.0 → 1.0.0`) |

Also updates the note in `docs/release_workflow.md` to remove the reference to the deleted flag.