### PR TITLE
test(chat): address PR #13 review comments on verify-ui scripts

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "npx",
         "-y",
-        "chrome-devtools-mcp@latest",
+        "chrome-devtools-mcp@1.3.0",
         "--isolated",
         "--screenshot-format=jpeg",
         "--no-usage-statistics"

--- a/scripts/verify-ui-precheck.sh
+++ b/scripts/verify-ui-precheck.sh
@@ -55,15 +55,29 @@ fi
 # ── 3. Plugin app route loads ──────────────────────────────────────────────────
 if [ "${HTTP_STATUS}" = "200" ]; then
   printf "Checking plugin app route... "
+  # Follow redirects and capture both the final status and final URL.
+  # A redirect to /login means auth is not configured — treat as failure.
+  PLUGIN_EFFECTIVE_URL=$(curl -s -o /dev/null -w "%{url_effective}" --max-time 5 \
+    -L "${GRAFANA_URL}${PLUGIN_APP_PATH}" 2>/dev/null || echo "")
   PLUGIN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
-    "${GRAFANA_URL}${PLUGIN_APP_PATH}" 2>/dev/null || echo "000")
-  if [ "${PLUGIN_STATUS}" = "200" ] || [ "${PLUGIN_STATUS}" = "302" ]; then
-    pass "Plugin route ${PLUGIN_APP_PATH} responds (HTTP ${PLUGIN_STATUS})"
-  else
-    fail "Plugin route ${PLUGIN_APP_PATH} returned HTTP ${PLUGIN_STATUS}"
-    echo "      The plugin may not be loaded. Check: docker logs ${PLUGIN_ID}"
-    ERRORS=$((ERRORS + 1))
-  fi
+    -L "${GRAFANA_URL}${PLUGIN_APP_PATH}" 2>/dev/null || echo "000")
+  case "${PLUGIN_EFFECTIVE_URL}" in
+    */login*|*/auth/login*)
+      fail "Plugin route redirected to login page — anonymous auth may be disabled"
+      echo "      Effective URL: ${PLUGIN_EFFECTIVE_URL}"
+      echo "      Restart with anonymous auth: npm run server"
+      ERRORS=$((ERRORS + 1))
+      ;;
+    *)
+      if [ "${PLUGIN_STATUS}" = "200" ]; then
+        pass "Plugin route ${PLUGIN_APP_PATH} responds (HTTP 200)"
+      else
+        fail "Plugin route ${PLUGIN_APP_PATH} returned HTTP ${PLUGIN_STATUS}"
+        echo "      The plugin may not be loaded. Check: docker logs ${PLUGIN_ID}"
+        ERRORS=$((ERRORS + 1))
+      fi
+      ;;
+  esac
 fi
 
 # ── 4. grafana-llm-app health ─────────────────────────────────────────────────
@@ -77,9 +91,20 @@ if [ "${HTTP_STATUS}" = "200" ]; then
     warn "LLM plugin health endpoint not reachable"
     echo "      The grafana-llm-app may still be installing (wait ~30s on first start)."
   else
-    # Check if llmProvider.ok is true in the JSON response
-    LLM_OK=$(echo "${LLM_BODY}" | grep -o '"ok":true' | head -1 || echo "")
-    if [ -n "${LLM_OK}" ]; then
+    # Specifically check details.llmProvider.ok — a shallow grep for "ok":true
+    # can produce false positives when other nested fields contain an ok flag.
+    LLM_OK=$(echo "${LLM_BODY}" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    provider = d.get('details', {}).get('llmProvider', {})
+    ok = provider.get('ok') is True
+    models_ok = provider.get('models', {}).get('base', {}).get('ok') is True
+    print('true' if (ok and models_ok) else 'false')
+except Exception:
+    print('false')
+" 2>/dev/null || echo "false")
+    if [ "${LLM_OK}" = "true" ]; then
       pass "grafana-llm-app is configured and healthy"
     else
       warn "grafana-llm-app is not configured or unhealthy"

--- a/scripts/verify-ui-precheck.sh
+++ b/scripts/verify-ui-precheck.sh
@@ -55,12 +55,12 @@ fi
 # ── 3. Plugin app route loads ──────────────────────────────────────────────────
 if [ "${HTTP_STATUS}" = "200" ]; then
   printf "Checking plugin app route... "
-  # Follow redirects and capture both the final status and final URL.
-  # A redirect to /login means auth is not configured — treat as failure.
-  PLUGIN_EFFECTIVE_URL=$(curl -s -o /dev/null -w "%{url_effective}" --max-time 5 \
-    -L "${GRAFANA_URL}${PLUGIN_APP_PATH}" 2>/dev/null || echo "")
-  PLUGIN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
-    -L "${GRAFANA_URL}${PLUGIN_APP_PATH}" 2>/dev/null || echo "000")
+  # Single request: capture both the final status and effective URL atomically.
+  # A redirect to /login means anonymous auth is misconfigured — treat as failure.
+  _plugin_out=$(curl -s -o /dev/null -w "%{http_code} %{url_effective}" --max-time 5 \
+    -L "${GRAFANA_URL}${PLUGIN_APP_PATH}" 2>/dev/null || echo "000 ")
+  PLUGIN_STATUS="${_plugin_out%% *}"
+  PLUGIN_EFFECTIVE_URL="${_plugin_out#* }"
   case "${PLUGIN_EFFECTIVE_URL}" in
     */login*|*/auth/login*)
       fail "Plugin route redirected to login page — anonymous auth may be disabled"
@@ -93,7 +93,10 @@ if [ "${HTTP_STATUS}" = "200" ]; then
   else
     # Specifically check details.llmProvider.ok — a shallow grep for "ok":true
     # can produce false positives when other nested fields contain an ok flag.
-    LLM_OK=$(echo "${LLM_BODY}" | python3 -c "
+    # Use python3 when available; fall back to a targeted grep on the llmProvider
+    # object only. printf '%s' avoids echo escape-handling differences in /bin/sh.
+    if command -v python3 > /dev/null 2>&1; then
+      LLM_OK=$(printf '%s' "${LLM_BODY}" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
@@ -104,6 +107,16 @@ try:
 except Exception:
     print('false')
 " 2>/dev/null || echo "false")
+    else
+      # python3 not available — extract just the llmProvider object with awk so
+      # we don't match ok flags in other sections of the response.
+      _provider_json=$(printf '%s' "${LLM_BODY}" | \
+        awk 'BEGIN{p=0} /"llmProvider"/{p=1} p{print} p && /}/{p=0}')
+      case "${_provider_json}" in
+        *'"ok":true'*) LLM_OK="true" ;;
+        *)             LLM_OK="false" ;;
+      esac
+    fi
     if [ "${LLM_OK}" = "true" ]; then
       pass "grafana-llm-app is configured and healthy"
     else

--- a/scripts/wait-for-plugin-reload.sh
+++ b/scripts/wait-for-plugin-reload.sh
@@ -25,8 +25,17 @@ set -e
 GRAFANA_URL="${GRAFANA_URL:-http://localhost:3000}"
 PLUGIN_ID="vikshana-graft-app"
 MODULE_URL="${GRAFANA_URL}/public/plugins/${PLUGIN_ID}/module.js"
-TIMEOUT="${1:-60}"
 POLL_INTERVAL=2
+
+# Validate timeout argument is a positive integer
+_raw_timeout="${1:-60}"
+case "${_raw_timeout}" in
+  ''|*[!0-9]*)
+    echo "Error: timeout_seconds must be a positive integer, got: '${_raw_timeout}'" >&2
+    exit 1
+    ;;
+esac
+TIMEOUT="${_raw_timeout}"
 
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'

--- a/scripts/wait-for-plugin-reload.sh
+++ b/scripts/wait-for-plugin-reload.sh
@@ -27,7 +27,7 @@ PLUGIN_ID="vikshana-graft-app"
 MODULE_URL="${GRAFANA_URL}/public/plugins/${PLUGIN_ID}/module.js"
 POLL_INTERVAL=2
 
-# Validate timeout argument is a positive integer
+# Validate timeout argument is a positive integer (> 0)
 _raw_timeout="${1:-60}"
 case "${_raw_timeout}" in
   ''|*[!0-9]*)
@@ -35,6 +35,10 @@ case "${_raw_timeout}" in
     exit 1
     ;;
 esac
+if [ "${_raw_timeout}" -le 0 ]; then
+  echo "Error: timeout_seconds must be greater than 0, got: '${_raw_timeout}'" >&2
+  exit 1
+fi
 TIMEOUT="${_raw_timeout}"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
Addresses all four review comments raised against the now-merged #13. Rebased cleanly onto main — single commit, three files only.

## Changes

### `scripts/wait-for-plugin-reload.sh`
**TIMEOUT integer validation** — validate `timeout_seconds` is a positive integer before using it in the `-lt` comparison. A non-integer argument (e.g. `sh ... foo`) would cause the `[` test to error and exit unexpectedly under `set -e`. Now fails early with a clear message.

### `scripts/verify-ui-precheck.sh`
**HTTP 302 redirect detection** — the plugin app route check now follows redirects (`curl -L`) and inspects the effective URL. If the final URL contains `/login`, the check fails with an actionable message. Previously a redirect to the login page was silently treated as success, masking an auth misconfiguration that would block the actual browser verification.

**LLM health JSON parsing** — replaced the shallow `grep -o '"ok":true'` with a `python3` JSON parse that specifically checks `details.llmProvider.ok` and `details.llmProvider.models.base.ok`. The old grep could produce a false positive if any other nested field contained an `ok` flag while the actual LLM provider was unconfigured.

### `opencode.json`
**Pin chrome-devtools-mcp version** — changed `@latest` to `@1.3.0` (current stable). `@latest` makes the workflow non-reproducible: a new upstream release could silently change command flags or tool behaviour. Version is now pinned and should be updated intentionally.