### PR TITLE
fix(llm): generate dashboard title from PLAN phase findings

### DIFF
--- a/src/services/agents/dashboardAgent.test.ts
+++ b/src/services/agents/dashboardAgent.test.ts
@@ -47,12 +47,14 @@ const prometheusFindings: DataFindings = {
 };
 
 /** Build a valid PLAN phase JSON response */
-const makePlanResponse = (panels?: any[]) => {
+const makePlanResponse = (panels?: any[], overrides?: { title?: string; description?: string }) => {
     const defaultPanels = [
         { title: 'Error Log Volume', description: 'Log error rate', query: '{job=~".+"} |= "error"', datasourceType: 'loki', viz: 'timeseries', unit: 'reqps', rowGroup: 'Errors' },
         { title: 'All Logs', description: 'All log streams', query: '{job=~".+"}', datasourceType: 'loki', viz: 'logs', unit: '', rowGroup: 'Logs' },
     ];
     return JSON.stringify({
+        title: overrides?.title ?? 'Service Log Monitoring',
+        description: overrides?.description ?? 'Monitors log volume and error rates for observed services.',
         panels: panels ?? defaultPanels,
         variables: [],
         timeRange: { from: 'now-1h', to: 'now' },
@@ -498,6 +500,62 @@ describe('runDashboardAgent', () => {
         expect(dash).toBeDefined();
         expect(Array.isArray(dash.panels)).toBe(true);
         expect(result.dashboardUid).toBe('uid-direct');
+    });
+
+    it('dashboard title comes from PLAN phase, not from the raw user message', async () => {
+        // The user asked a conversational question — it should never become the title.
+        const conversationalUserMessage = 'Can you build a dashboard to monitor this?';
+
+        mockChatCompletions.mockResolvedValueOnce(
+            makeResponse(makePlanResponse(undefined, { title: 'OTel Receiver Metrics' }))
+        );
+        mockMcpClient.callTool
+            .mockResolvedValueOnce(makeUpdateDashboardResult('uid-title'))
+            .mockResolvedValueOnce(makeSummaryEnvelope(2, [
+                { id: 1, title: 'Error Log Volume', type: 'timeseries', description: 'd', queryCount: 1 },
+                { id: 2, title: 'All Logs', type: 'logs', description: 'd', queryCount: 1 },
+            ]))
+            .mockResolvedValueOnce(makePanelQueriesEnvelope());
+
+        await runDashboardAgent(
+            makeStep(), conversationalUserMessage, '', lokiFindings,
+            [], mockMcpClient, 10, new AbortController().signal, onUpdate,
+        );
+
+        const dash = mockMcpClient.callTool.mock.calls[0][0].arguments.dashboard;
+        expect(dash.title).toBe('OTel Receiver Metrics');
+        expect(dash.title).not.toContain('Can You');
+        expect(dash.title).not.toContain('build a dashboard');
+    });
+
+    it('falls back to step.description as dashboard title when PLAN omits title', async () => {
+        // PLAN response that intentionally has no "title" field
+        const planWithNoTitle = JSON.stringify({
+            panels: [
+                { title: 'Error Log Volume', description: 'Log error rate', query: '{job=~".+"} |= "error"',
+                  datasourceType: 'loki', viz: 'timeseries', unit: 'reqps', rowGroup: 'Errors' },
+            ],
+            variables: [],
+            timeRange: { from: 'now-1h', to: 'now' },
+            layoutHint: 'none',
+        });
+
+        mockChatCompletions.mockResolvedValueOnce(makeResponse(planWithNoTitle));
+        mockMcpClient.callTool
+            .mockResolvedValueOnce(makeUpdateDashboardResult('uid-fallback'))
+            .mockResolvedValueOnce(makeSummaryEnvelope(1, [
+                { id: 1, title: 'Error Log Volume', type: 'timeseries', description: 'd', queryCount: 1 },
+            ]))
+            .mockResolvedValueOnce(makePanelQueriesEnvelope());
+
+        const step = makeStep({ description: 'Build a service log monitoring dashboard' });
+        await runDashboardAgent(
+            step, 'Can you build a dashboard to monitor this?', '', lokiFindings,
+            [], mockMcpClient, 10, new AbortController().signal, onUpdate,
+        );
+
+        const dash = mockMcpClient.callTool.mock.calls[0][0].arguments.dashboard;
+        expect(dash.title).toBe('Build a service log monitoring dashboard');
     });
 
     it('code-built CREATE: query from PLAN is written verbatim into the panel target', async () => {

--- a/src/services/agents/dashboardAgent.ts
+++ b/src/services/agents/dashboardAgent.ts
@@ -1286,8 +1286,12 @@ function parsePlanResponse(content: string): { panels: any[]; variables: any[]; 
             variables: Array.isArray(parsed.variables) ? parsed.variables : [],
             timeRange: parsed.timeRange ?? { from: 'now-1h', to: 'now' },
             layoutHint: parsed.layoutHint,
-            title: typeof parsed.title === 'string' && parsed.title.trim() ? parsed.title.trim() : undefined,
-            description: typeof parsed.description === 'string' && parsed.description.trim() ? parsed.description.trim() : undefined,
+            title: typeof parsed.title === 'string' && parsed.title.trim()
+                ? parsed.title.trim().replace(/\s+/g, ' ').slice(0, 80)
+                : undefined,
+            description: typeof parsed.description === 'string' && parsed.description.trim()
+                ? parsed.description.trim().replace(/\s+/g, ' ').slice(0, 300)
+                : undefined,
         };
     } catch {
         return null;
@@ -1347,7 +1351,7 @@ export async function runDashboardAgent(
         // Gate: at least 1 panel in the todo list.
         // ═══════════════════════════════════════════════════════════════════
 
-        let planResult: { panels: any[]; variables: any[]; timeRange: any; layoutHint?: string; title?: string; description?: string } | null = null;
+        let planResult: ReturnType<typeof parsePlanResponse> = null;
         let planAttempt = 0;
 
         while (!planResult && planAttempt <= MAX_PLAN_RETRIES) {

--- a/src/services/agents/dashboardAgent.ts
+++ b/src/services/agents/dashboardAgent.ts
@@ -417,6 +417,8 @@ ${context ? `## Current Grafana context\n${context}` : ''}
 
 ## Output format (REQUIRED — output ONLY this JSON, no prose, no fences)
 {
+  "title": "<3-6 word dashboard name derived from the datasource and metric domain — e.g. 'OTel Receiver Metrics', 'API Error Rate', 'Kubernetes Node Health'>",
+  "description": "<1-2 sentence description of what this dashboard monitors and why>",
   "panels": [
     {
       "title": "<panel title>",
@@ -440,6 +442,8 @@ ${context ? `## Current Grafana context\n${context}` : ''}
 }
 
 Rules:
+- title: derive from the datasource name and metric domain. Do NOT copy the user's question. Max 6 words, title case. Examples: "OTel Receiver Metrics", "Frontend Request Rate", "Node Exporter Health".
+- description: 1-2 sentences describing what the dashboard monitors. Write as a statement, not a question.
 - If pre-validated queries were provided: use the EXACT expression strings from the findings. Do NOT rephrase or reconstruct.
 - If an available metrics list is shown above: write PromQL expressions using ONLY those exact metric names. Do NOT use metric names outside that list. Do NOT guess names that "should" exist.
 - If NO pre-validated queries AND NO available metrics list: set query to "DISCOVER" for every panel.
@@ -1267,7 +1271,7 @@ async function runAgentLoop(
 // ─── Phase helpers ────────────────────────────────────────────────────────────
 
 /** Parse the panel todo list from the PLAN phase response. Returns null on failure. */
-function parsePlanResponse(content: string): { panels: any[]; variables: any[]; timeRange: any; layoutHint?: string } | null {
+function parsePlanResponse(content: string): { panels: any[]; variables: any[]; timeRange: any; layoutHint?: string; title?: string; description?: string } | null {
     try {
         let json = content.trim();
         const fence = json.match(/```(?:json)?\s*([\s\S]*?)```/i);
@@ -1282,6 +1286,8 @@ function parsePlanResponse(content: string): { panels: any[]; variables: any[]; 
             variables: Array.isArray(parsed.variables) ? parsed.variables : [],
             timeRange: parsed.timeRange ?? { from: 'now-1h', to: 'now' },
             layoutHint: parsed.layoutHint,
+            title: typeof parsed.title === 'string' && parsed.title.trim() ? parsed.title.trim() : undefined,
+            description: typeof parsed.description === 'string' && parsed.description.trim() ? parsed.description.trim() : undefined,
         };
     } catch {
         return null;
@@ -1404,12 +1410,10 @@ export async function runDashboardAgent(
         // ═══════════════════════════════════════════════════════════════════
 
         if (plannedPanels.length > 0 && mcpClient) {
-            // Generate a descriptive title from the user message
-            const dashTitle = userMessage.length < 60
-                ? userMessage.replace(/^(create|build|make|add)\s+a?\s*/i, '').trim()
-                    .replace(/\b\w/g, c => c.toUpperCase())
-                : step.description;
-            const dashDesc = `Auto-generated dashboard for: ${userMessage}`;
+            // Use the LLM-generated title/description from the PLAN phase — it knows the
+            // datasource and metric domain. Fall back to the planner's step description.
+            const dashTitle = planResult?.title || step.description;
+            const dashDesc = planResult?.description || `Dashboard for: ${step.description}`;
 
             const dashboardJson = buildDashboardJson(
                 layout, plannedPanels, plannedVariables, plannedTimeRange,

--- a/src/services/agents/dashboardAgent.ts
+++ b/src/services/agents/dashboardAgent.ts
@@ -1347,7 +1347,7 @@ export async function runDashboardAgent(
         // Gate: at least 1 panel in the todo list.
         // ═══════════════════════════════════════════════════════════════════
 
-        let planResult: { panels: any[]; variables: any[]; timeRange: any; layoutHint?: string } | null = null;
+        let planResult: { panels: any[]; variables: any[]; timeRange: any; layoutHint?: string; title?: string; description?: string } | null = null;
         let planAttempt = 0;
 
         while (!planResult && planAttempt <= MAX_PLAN_RETRIES) {


### PR DESCRIPTION
## Problem

When a user asks Graft to build a dashboard via a conversational message (e.g. *"Can you build a dashboard to monitor this?"*), the dashboard ended up named **"Can You Build A Dashboard To Monitor This?"** — the raw user message title-cased verbatim.

The root cause was a naive heuristic in `dashboardAgent.ts` that tried to strip leading action verbs (`^create|build|make|add`) and title-case the remainder. Any phrasing where the verb wasn't the first word bypassed the strip entirely.

## Solution

Add `title` and `description` fields to the PLAN phase JSON output schema. The PLAN phase already runs an LLM call with full context (datasource names, validated queries, metric domain) — the right place to generate a meaningful name at zero extra cost.

The model is instructed to derive a short, domain-aware title (max 6 words, title case) from the findings — e.g. *"OTel Receiver Metrics"*, *"API Error Rate"*, *"Kubernetes Node Health"* — and never copy the user's question.

## Changes

**`src/services/agents/dashboardAgent.ts`**
- `buildPlanPhasePrompt`: add `title` and `description` to the JSON output schema with explicit rules (max 6 words, derived from datasource/metric domain, never a copy of the user's question)
- `parsePlanResponse`: extend return type and value to carry `title?` and `description?`
- `planResult` type annotation: updated to match the new return type
- CREATE phase: replace the 4-line heuristic with `planResult?.title || step.description`

**`src/services/agents/dashboardAgent.test.ts`**
- `makePlanResponse` helper: includes `title` and `description` in default plan JSON (with optional override parameter)
- Two new regression tests:
  - *title comes from PLAN phase, not from the raw user message* — asserts `"OTel Receiver Metrics"` reaches `update_dashboard` even when `userMessage` is a question
  - *falls back to step.description when PLAN omits title* — asserts graceful fallback when the PLAN JSON has no `title` field

## Test results

- Unit tests: 367/367 ✓
- E2E tests: 27/27 passed, 3 skipped (pre-existing LLM-provider skips) ✓
- TypeScript: clean ✓