### PR TITLE
fix(release): trigger artifact builds for graft tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Build and publish a GitHub Release for every vX.Y.Z tag.
+# Build and publish a GitHub Release for every graft-vX.Y.Z tag.
 # Tags are created automatically by the release-please workflow when its
 # Release PR is merged. See docs/release_workflow.md for the full process.
 name: Release
@@ -6,7 +6,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'graft-v*'
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary
- trigger the release artifact workflow for `graft-v*` tags
- align workflow documentation with release-please’s prefixed tags

## Verification
- `git diff --check`

Merging this workflow-only fix will not immediately create a release or retroactively attach assets. It will cause release-please to open a patch release PR; merging that generated PR creates the next `graft-v*` tag, which triggers packaging and attaches the ZIP. Existing tag releases require a manual rerun/release process.