### PR TITLE
fix(release): package artifacts in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,63 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - id: release
+        uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install Mage
+        run: go install github.com/magefile/mage@latest
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Build backend
+        run: mage -v
+
+      - name: Get plugin metadata
+        id: metadata
+        run: |
+          echo "plugin-id=$(cat dist/plugin.json | jq -r '.id')" >> $GITHUB_OUTPUT
+          echo "archive=$(cat dist/plugin.json | jq -r '.id')-${{ needs.release-please.outputs.tag_name }}.zip" >> $GITHUB_OUTPUT
+
+      - name: Package plugin
+        run: |
+          mv dist ${{ steps.metadata.outputs.plugin-id }}
+          zip -r ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }}
+
+      - name: Upload release artifact
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          files: ${{ steps.metadata.outputs.archive }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,14 @@
-# Build and publish a GitHub Release for every graft-vX.Y.Z tag.
-# Tags are created automatically by the release-please workflow when its
-# Release PR is merged. See docs/release_workflow.md for the full process.
+# Manual recovery workflow: rebuild and upload artifacts for an existing
+# graft-vX.Y.Z release tag when automation needs a rerun.
 name: Release
 
 on:
-  push:
-    tags:
-      - 'graft-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to rebuild (e.g., graft-v0.6.2)'
+        required: true
+        type: string
 
 permissions: read-all
 
@@ -17,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -51,15 +55,15 @@ jobs:
         id: metadata
         run: |
           echo "plugin-id=$(cat dist/plugin.json | jq -r '.id')" >> $GITHUB_OUTPUT
-          echo "archive=$(cat dist/plugin.json | jq -r '.id')-${{ github.ref_name }}.zip" >> $GITHUB_OUTPUT
+          echo "archive=$(cat dist/plugin.json | jq -r '.id')-${{ inputs.tag }}.zip" >> $GITHUB_OUTPUT
 
       - name: Package plugin
         run: |
           mv dist ${{ steps.metadata.outputs.plugin-id }}
           zip -r ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }}
 
-      - name: Create release
+      - name: Upload release artifact
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag }}
           files: ${{ steps.metadata.outputs.archive }}
-          generate_release_notes: true

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -11,7 +11,8 @@ Graft uses **Conventional Commits** and **release-please** to automate the relea
 1. Developers merge feature/fix PRs to `main` using Conventional Commit messages.
 2. After each merge, release-please opens (or updates) a **Release PR** automatically. This PR contains the version bump to `package.json` and the auto-generated `CHANGELOG.md` entries.
 3. When the team is ready to cut a release, they **merge the Release PR**.
-4. Merging the Release PR causes release-please to push a `vX.Y.Z` tag, which triggers the `release.yml` workflow to build and publish the GitHub Release.
+4. Merging the Release PR causes release-please to create/update the GitHub Release and push a `graft-vX.Y.Z` tag.
+5. In the same `release-please.yml` run, a `package` job (gated on `release_created == 'true'`) checks out that tag, builds the plugin, and uploads the artifact to the existing release.
 
 No manual version editing, no manual tagging, no manual changelog writing.
 
@@ -63,15 +64,28 @@ If a commit message was wrong and the version bump is incorrect, you can overrid
 ### 4. Merge the Release PR
 
 When ready to release, simply **merge the Release PR**. release-please will:
-- Push a `vX.Y.Z` tag to `main`
+- Push a `graft-vX.Y.Z` tag to `main`
+- Create/update the GitHub Release notes for that tag
 
-### 5. Automated build and publish
+### 5. Automated build and publish (same workflow)
 
-The `vX.Y.Z` tag push triggers `.github/workflows/release.yml`, which:
+The same `.github/workflows/release-please.yml` run then executes a `package` job (only when `release_created == 'true'`) that:
 1. Builds the frontend (`npm run build`)
 2. Builds the Go backend for all platforms (`mage -v`)
-3. Packages `dist/` as `vikshana-graft-app-vX.Y.Z.zip`
-4. Creates a GitHub Release and attaches the zip as a downloadable artifact
+3. Packages `dist/` as `vikshana-graft-app-graft-vX.Y.Z.zip`
+4. Uploads the zip artifact to the existing `graft-vX.Y.Z` GitHub Release
+
+### 6. Manual recovery (artifact upload only)
+
+If the automated packaging/upload job fails or needs to be re-run, use **Actions → Release** (`.github/workflows/release.yml`) and dispatch it manually with an existing tag, for example:
+
+```
+graft-v0.6.2
+```
+
+This workflow checks out the provided tag, rebuilds the plugin, and uploads `vikshana-graft-app-graft-vX.Y.Z.zip` to that existing release.
+
+It is a recovery path only — it does **not** create a new release or regenerate release notes.
 
 The release is then available at:
 ```
@@ -84,10 +98,10 @@ https://github.com/vikshana/vikshana-graft-app/releases
 
 | File | Purpose |
 |---|---|
-| `.github/workflows/release-please.yml` | Runs release-please on every push to `main` |
+| `.github/workflows/release-please.yml` | Runs release-please on every push to `main`, then packages/uploads artifacts when a release is created |
 | `release-please-config.json` | Configures release type, changelog sections, and version bump behaviour |
 | `.release-please-manifest.json` | Tracks the last released version; updated automatically by release-please — do not edit manually |
-| `.github/workflows/release.yml` | Builds and publishes the plugin artifact when a `v*` tag is pushed |
+| `.github/workflows/release.yml` | Manual recovery workflow: rebuilds/uploads artifacts for an existing `graft-v*` release tag |
 
 ---
 
@@ -97,7 +111,7 @@ https://github.com/vikshana/vikshana-graft-app/releases
 
 | Placeholder | Replaced with |
 |---|---|
-| `%VERSION%` | The version from the git tag (e.g. `v0.3.0` → `0.3.0`) |
+| `%VERSION%` | The version from the git tag (e.g. `graft-v0.3.0` → `0.3.0`) |
 | `%TODAY%` | The current date in `YYYY-MM-DD` format |
 
 The source file always keeps the placeholders — substitution only happens in the built artifact inside `dist/`.
@@ -108,7 +122,7 @@ The source file always keeps the placeholders — substitution only happens in t
 
 For urgent fixes that can't wait for the next scheduled release:
 
-1. Create a branch from the release tag: `git checkout -b hotfix/0.2.1 v0.2.0`
+1. Create a branch from the release tag: `git checkout -b hotfix/0.2.1 graft-v0.2.0`
 2. Apply the fix with a `fix:` commit
 3. Open a PR against `main` (and backport to the release branch if needed)
 4. Once merged, the Release PR on `main` will propose the patch bump — merge it immediately


### PR DESCRIPTION
## Summary
- package and upload the plugin ZIP as a job in the release-please workflow that creates the release
- retain a manual tag-based artifact-recovery workflow
- document the `graft-v*` release lifecycle and recovery procedure

## Verification
- `ruby -e "require 'yaml'; %w[.github/workflows/release-please.yml .github/workflows/release.yml].each { |path| YAML.load_file(path); puts \"#{path}: valid YAML\" }"`
- `npm run build`
- `go test ./pkg/...`
- `npm run test:ci`
- `git diff --check`

The existing `graft-v0.6.2` release can be repaired after merging by manually dispatching the **Release** workflow with tag `graft-v0.6.2`.