### PR TITLE
fix(chat): greet users by first name

### DIFF
--- a/src/components/features/ChatInterface/ChatInterface.test.tsx
+++ b/src/components/features/ChatInterface/ChatInterface.test.tsx
@@ -117,6 +117,10 @@ describe('ChatInterface', () => {
         window.FileReader = MockFileReader;
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it('renders the landing page initially', async () => {
         render(
             <MemoryRouter>
@@ -128,6 +132,37 @@ describe('ChatInterface', () => {
             expect(screen.getByTestId('landing-title')).toBeInTheDocument();
         });
         expect(screen.getByText('Previous Conversations')).toBeInTheDocument();
+    });
+
+    it('uses the first whitespace-delimited name in the landing greeting', async () => {
+        jest.spyOn(Date.prototype, 'getHours').mockReturnValue(9);
+        (contextService.getUserContext as jest.Mock).mockReturnValue({ login: 'testuser', name: '  Test   User  ' });
+
+        render(
+            <MemoryRouter>
+                <ChatInterface />
+            </MemoryRouter>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('landing-title')).toHaveTextContent('Good Morning, Test!');
+        });
+    });
+
+    it('falls back to the time greeting when no selected name or login is available', async () => {
+        jest.spyOn(Date.prototype, 'getHours').mockReturnValue(9);
+        (contextService.getUserContext as jest.Mock).mockReturnValue({});
+
+        render(
+            <MemoryRouter>
+                <ChatInterface />
+            </MemoryRouter>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('landing-title')).toHaveTextContent('Good Morning');
+        });
+        expect(screen.getByTestId('landing-title')).not.toHaveTextContent(',');
     });
 
     it('switches to chat view when sending a message', async () => {

--- a/src/components/features/ChatInterface/ChatInterface.tsx
+++ b/src/components/features/ChatInterface/ChatInterface.tsx
@@ -74,9 +74,16 @@ const getTimeBasedGreeting = (): string => {
 };
 
 // Helper function to get greeting message with optional user name
+const getFirstName = (value?: string): string | undefined => {
+  const firstName = value?.trim().split(/\s+/).find(Boolean);
+  return firstName || undefined;
+};
+
+// Helper function to get greeting message with optional user name
 const getGreetingMessage = (userName?: string): string => {
   const timeGreeting = getTimeBasedGreeting();
-  return userName ? `${timeGreeting}, ${userName}!` : timeGreeting;
+  const firstName = getFirstName(userName);
+  return firstName ? `${timeGreeting}, ${firstName}!` : timeGreeting;
 };
 
 // Custom hook for rolling placeholder text with typing animation

--- a/src/components/features/ChatInterface/ChatInterface.tsx
+++ b/src/components/features/ChatInterface/ChatInterface.tsx
@@ -73,7 +73,7 @@ const getTimeBasedGreeting = (): string => {
   }
 };
 
-// Helper function to get greeting message with optional user name
+// Helper function to extract the first whitespace-delimited name (if any)
 const getFirstName = (value?: string): string | undefined => {
   const firstName = value?.trim().split(/\s+/).find(Boolean);
   return firstName || undefined;


### PR DESCRIPTION
## Summary
- show only the first whitespace-delimited name in the landing greeting
- add coverage for full-name and empty-name greetings

## Verification
- npm run test:ci
- go test ./pkg/...
- npm run build
- npm run e2e
- verified landing UI in Grafana (console clean; screenshot: output/chat-landing-first-name-greeting.png)