### PR TITLE
ci(deps): configure Renovate updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,6 +11,14 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App installation token
+        id: renovate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: renovatebot/github-action@v46.2.3
         with:
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ steps.renovate-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,14 +5,15 @@ on:
     - cron: '17 3 * * *'
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create GitHub App installation token
         id: renovate-token
@@ -20,8 +21,7 @@ jobs:
         with:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
+          repositories: ${{ github.repository }}
 
       - name: Run Renovate
         uses: renovatebot/github-action@v46.2.3

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,6 +11,9 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Create GitHub App installation token
         id: renovate-token
         uses: actions/create-github-app-token@v2
@@ -18,7 +21,12 @@ jobs:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
-      - uses: renovatebot/github-action@v46.2.3
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.2.3
         with:
           token: ${{ steps.renovate-token.outputs.token }}
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,16 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: renovatebot/github-action@v46.2.3
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["npm", "gomod", "docker-compose", "github-actions"],
+  "dependencyDashboard": true
+}


### PR DESCRIPTION
## Summary

- Add Renovate configuration for npm, Go modules, Docker Compose, and GitHub Actions.
- Run self-hosted Renovate daily at 03:17 UTC, with an on-demand workflow trigger.
- Generate a short-lived GitHub App installation token for each Renovate run, limited to this repository.
- Enable the Renovate Dependency Dashboard.

## Required setup

Configure organization or repository Actions secrets for the installed GitHub App:

- `RENOVATE_APP_ID`
- `RENOVATE_APP_PRIVATE_KEY`

## Validation

- `npx --yes --package renovate renovate-config-validator`
- `npx --yes prettier@2.8.8 --check .github/workflows/renovate.yml`