### PR TITLE
fix(deps): scope Renovate app token correctly

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,7 +21,8 @@ jobs:
         with:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
-          repositories: ${{ github.repository }}
+          owner: ${{ github.repository_owner }}
+          repositories: vikshana-graft-app
 
       - name: Run Renovate
         uses: renovatebot/github-action@v46.2.3


### PR DESCRIPTION
## Summary

- pass the repository name, rather than its owner/name slug, when minting the GitHub App installation token
- retain explicit organization ownership and scope the token to `vikshana-graft-app`

## Validation

- `npx --yes --package renovate renovate-config-validator`
- `npx --yes prettier@2.8.8 --check .github/workflows/renovate.yml`