### PR TITLE
ci(renovate): reduce Renovate workflow logging

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -29,5 +29,4 @@ jobs:
         with:
           token: ${{ steps.renovate-token.outputs.token }}
         env:
-          LOG_LEVEL: debug
           RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- remove the debug log-level override from the Renovate workflow
- retain standard Renovate logs for scheduled and manual runs

## Validation

- `npx --yes --package renovate renovate-config-validator`
- `npx --yes prettier@2.8.8 --check .github/workflows/renovate.yml`