### PR TITLE
fix(release): publish chore dependency updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ Commit types and their effect on versioning:
 | `feat!` / `BREAKING CHANGE:` footer | Incompatible API change | Major (`0.2.0 → 1.0.0`) |
 | `perf` | Performance improvement | Patch |
 | `docs` | Documentation only | No bump (visible in changelog) |
-| `chore` | Maintenance, dependency updates | No bump |
+| `chore` | Maintenance, dependency updates | Patch (`0.2.0 → 0.2.1`) (shown under Dependencies in changelog) |
 | `refactor` | Code restructure, no behaviour change | No bump |
 | `test` | Adding or fixing tests | No bump |
 | `ci` | CI/CD pipeline changes | No bump |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ Commit types and their effect on versioning:
 | `feat!` / `BREAKING CHANGE:` footer | Incompatible API change | Major (`0.2.0 → 1.0.0`) |
 | `perf` | Performance improvement | Patch |
 | `docs` | Documentation only | No bump (visible in changelog) |
-| `chore` | Maintenance, dependency updates | Patch (`0.2.0 → 0.2.1`) (shown under Dependencies in changelog) |
+| `chore` | Maintenance, dependency updates | Patch (`0.2.0 → 0.2.1`) (shown under Miscellaneous & Dependencies in changelog) |
 | `refactor` | Code restructure, no behaviour change | No bump |
 | `test` | Adding or fixing tests | No bump |
 | `ci` | CI/CD pipeline changes | No bump |

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -27,7 +27,8 @@ Version bumps are determined automatically from commit message prefixes:
 | `fix:` | `fix: correct health check timeout` | Patch (`0.2.0 → 0.2.1`) |
 | `feat:` | `feat: add dark mode support` | Minor (`0.2.0 → 0.3.0`) |
 | `feat!:` or `BREAKING CHANGE:` footer | `feat!: redesign config API` | Major (`0.2.0 → 1.0.0`) |
-| `chore:`, `test:`, `ci:`, `refactor:`, `build:` | `chore: update dependencies` | No bump (hidden from changelog) |
+| `chore:` | `chore: update dependencies` | Patch (shown under Dependencies in changelog) |
+| `test:`, `ci:`, `refactor:`, `build:` | `test: add chat history tests` | No bump (hidden from changelog) |
 | `docs:` | `docs: improve setup guide` | No bump (shown in changelog) |
 | `perf:` | `perf: optimise bundle size` | Patch |
 

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -27,7 +27,7 @@ Version bumps are determined automatically from commit message prefixes:
 | `fix:` | `fix: correct health check timeout` | Patch (`0.2.0 → 0.2.1`) |
 | `feat:` | `feat: add dark mode support` | Minor (`0.2.0 → 0.3.0`) |
 | `feat!:` or `BREAKING CHANGE:` footer | `feat!: redesign config API` | Major (`0.2.0 → 1.0.0`) |
-| `chore:` | `chore: update dependencies` | Patch (shown under Dependencies in changelog) |
+| `chore:` | `chore: update dependencies` | Patch (shown under Miscellaneous & Dependencies in changelog) |
 | `test:`, `ci:`, `refactor:`, `build:` | `test: add chat history tests` | No bump (hidden from changelog) |
 | `docs:` | `docs: improve setup guide` | No bump (shown in changelog) |
 | `perf:` | `perf: optimise bundle size` | Patch |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,7 @@
         { "type": "perf",     "section": "Performance improvements" },
         { "type": "revert",   "section": "Reverts" },
         { "type": "docs",     "section": "Documentation", "hidden": false },
-        { "type": "chore",    "section": "Dependencies", "hidden": false },
+        { "type": "chore",    "section": "Miscellaneous & Dependencies", "hidden": false },
         { "type": "refactor", "section": "Miscellaneous", "hidden": true },
         { "type": "test",     "section": "Miscellaneous", "hidden": true },
         { "type": "build",    "section": "Miscellaneous", "hidden": true },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,7 @@
         { "type": "perf",     "section": "Performance improvements" },
         { "type": "revert",   "section": "Reverts" },
         { "type": "docs",     "section": "Documentation", "hidden": false },
-        { "type": "chore",    "section": "Miscellaneous", "hidden": true },
+        { "type": "chore",    "section": "Dependencies", "hidden": false },
         { "type": "refactor", "section": "Miscellaneous", "hidden": true },
         { "type": "test",     "section": "Miscellaneous", "hidden": true },
         { "type": "build",    "section": "Miscellaneous", "hidden": true },


### PR DESCRIPTION
## Summary
- publish `chore` commits under a dedicated **Dependencies** changelog section
- allow Renovate `chore(deps)` commits to be included in release notes and trigger Release Please’s default patch-release behavior

## Validation
- `node -e "JSON.parse(require("'node:fs'").readFileSync("'release-please-config.json'", "'utf8'")); console.log("'release-please-config.json is valid JSON'")"`
- `npm run test:ci`
- `go test ./pkg/...`
- E2E not run: Grafana/Docker is not running locally.